### PR TITLE
update macOS Makefiles

### DIFF
--- a/src/mac64/Makefile
+++ b/src/mac64/Makefile
@@ -10,15 +10,26 @@ COMPOBJS        = $(COMPOBJS_COMMON) prst.o
 
 VPATH     = ..:../../framework:../../framework/arithmetic
 
-LFLAGS    = -ld_classic
+LFLAGS    =
+
+# uncomment if running into linker bug
+#LFLAGS   += -ld_classic
 
 DUMMY2    =
 LIBS2     = -lm -lpthread -lstdc++ /usr/local/lib/libgmp.a  # link against .a file directly to avoid using .dylib
 
 CC = clang
-CXX = clang
-CFLAGS    = -I/usr/local/include/ -I.. -I../../framework/gwnum                                                -DGMP -DX86_64 -O2 -fno-limit-debug-info -g -std=c99     -Wall -Wextra -target x86_64-apple-macos10.15
-CXXFLAGS  = -I/usr/local/include/ -I.. -I../../framework -I../../framework/arithmetic -I../../framework/gwnum -DGMP -DX86_64 -O2 -fno-limit-debug-info -g -std=gnu++17 -Wall -Wextra -target x86_64-apple-macos10.15
+CXX = clang++
+CFLAGS    = -I/usr/local/include/ -I.. -I../../framework/gwnum                                                -DGMP -DX86_64 -O2 -g -fno-limit-debug-info -std=c99     -Wall -Wextra
+CXXFLAGS  = -I/usr/local/include/ -I.. -I../../framework -I../../framework/arithmetic -I../../framework/gwnum -DGMP -DX86_64 -O2 -g -fno-limit-debug-info -std=gnu++17 -Wall -Wextra
+
+CFLAGS   += -target x86_64-apple-macos10.13
+CXXFLAGS += -target x86_64-apple-macos10.13
+
+# asan flags
+#LFLAGS   += -fsanitize=address -fno-omit-frame-pointer
+#CFLAGS   += -fsanitize=address -fno-omit-frame-pointer
+#CXXFLAGS += -fsanitize=address -fno-omit-frame-pointer
 
 # the code is too noisy for all warnings
 CXXFLAGS += -Wno-sign-compare

--- a/src/mac64/Makefile
+++ b/src/mac64/Makefile
@@ -1,4 +1,4 @@
-# Makefile for Linux
+# Makefile for macOS
 
 EXE       = prst
 LIB_GWNUM = ../../framework/gwnum/mac64/gwnum.a
@@ -10,19 +10,15 @@ COMPOBJS        = $(COMPOBJS_COMMON) prst.o
 
 VPATH     = ..:../../framework:../../framework/arithmetic
 
-# See README.md for how to get macOS SDK
-LFLAGS    = # -isysroot MacOSX10.7.sdk/ -mmacosx-version-min=10.7
+LFLAGS    = -ld_classic
 
 DUMMY2    =
 LIBS2     = -lm -lpthread -lstdc++ /usr/local/lib/libgmp.a  # link against .a file directly to avoid using .dylib
 
-#CC        = /usr/local/bin/gcc-12 -mmacosx-version-min=10.9
-#CC        = /usr/local/bin/gcc-12
-#CXX       = /usr/local/bin/g++-12
-CC = gcc -mmacosx-version-min=10.13 -isysroot /Users/daohe/CLionProjects/prst/src/mac64/MacOSX10.13.sdk
-CXX = g++ -mmacosx-version-min=10.13 -isysroot /Users/daohe/CLionProjects/prst/src/mac64/MacOSX10.13.sdk
-CFLAGS    = -I/usr/local/include/ -I.. -I../../framework/gwnum                                                -DGMP -DX86_64 -O2 -std=c99     -Wall -Wextra
-CXXFLAGS  = -I/usr/local/include/ -I.. -I../../framework -I../../framework/arithmetic -I../../framework/gwnum -DGMP -DX86_64 -O2 -std=gnu++17 -Wall -Wextra
+CC = clang
+CXX = clang
+CFLAGS    = -I/usr/local/include/ -I.. -I../../framework/gwnum                                                -DGMP -DX86_64 -O2 -fno-limit-debug-info -g -std=c99     -Wall -Wextra -target x86_64-apple-macos10.15
+CXXFLAGS  = -I/usr/local/include/ -I.. -I../../framework -I../../framework/arithmetic -I../../framework/gwnum -DGMP -DX86_64 -O2 -fno-limit-debug-info -g -std=gnu++17 -Wall -Wextra -target x86_64-apple-macos10.15
 
 # the code is too noisy for all warnings
 CXXFLAGS += -Wno-sign-compare
@@ -34,5 +30,5 @@ all: $(EXE)
 $(EXE): $(COMPOBJS)
 	$(CC) $(LFLAGS) -o $@ $(COMPOBJS) $(LIB_GWNUM) $(LIBS2)
 
-clean:
+clean::
 	rm -f $(EXE) $(COMPOBJS)

--- a/src/mac64/Makefile.boinc
+++ b/src/mac64/Makefile.boinc
@@ -10,7 +10,7 @@ all_boinc: $(EXE_BOINC)
 include Makefile
 
 $(EXE_BOINC): $(COMPOBJS_COMMON) prst_boinc.o bow.o boinc.o
-	$(CC) -o $@ $^ $(LIB_GWNUM) $(DUMMY2) $(BOINC_LIB) $(LIBS2)
+	$(CC) $(LFLAGS) -o $@ $^ $(LIB_GWNUM) $(DUMMY2) $(BOINC_LIB) $(LIBS2)
 
 prst_boinc.o: prst.cpp
 	$(CXX) -o $@ -c $(CXXFLAGS) -DBOINC $<
@@ -20,3 +20,6 @@ boinc.o: boinc.cpp
 
 bow.o: bow/bow.cpp
 	$(CXX) -o $@ -c $(CXXFLAGS) $(BOINC_INC) $<
+
+clean::
+	rm -f $(EXE_BOINC) bow.o boinc.o prst_boinc.o


### PR DESCRIPTION
Edit: superseded by #5 

- now uses clang instead of gcc
- added `-ld_classic` to work around a linker bug (which happens regardless of gcc vs clang)
- removes the need to download SDK to target older macOS versions
- targets 10.15 as minimum supported version
- add clean target for Makefile.boinc to clean up boinc build artifacts