### PR TITLE
Shifts the compilation of mac prst from arm64 images to amd64 images

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   boinc-macIntel64:
-    runs-on: macos-15
+    runs-on: macos-15-intel
 
     steps:
       - name: Cache BOINC libs
@@ -32,7 +32,7 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         if: steps.cache-boinc-macIntel64.outputs.cache-hit != 'true'
         with:
-          xcode-version: '15.2.0'
+          xcode-version: '16.0.0'
 
       - name: Checkout boinc
         if: steps.cache-boinc-macIntel64.outputs.cache-hit != 'true'
@@ -49,7 +49,7 @@ jobs:
           source BuildMacBOINC.sh -lib
 
   gwnum:
-    runs-on: macos-15
+    runs-on: macos-15-intel
 
     steps:
       - name: Cache gwnum.a libs
@@ -78,7 +78,7 @@ jobs:
 
   macIntel64:
     needs: [boinc-macIntel64, gwnum]
-    runs-on: macos-15
+    runs-on: macos-15-intel
     env:
       SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
       LIBCXX_INCLUDE: /opt/libcxx-11/include/c++/v1

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -11,7 +11,7 @@ env:
   gwnum_ver: "v3103b01"
   gwnum_ver_major: "31"
   gwnum_ver_minor: "03"
-  MACOSX_DEPLOYMENT_TARGET: "10.14"
+  MACOSX_DEPLOYMENT_TARGET: "10.15"
 
 jobs:
   boinc-macIntel64:
@@ -80,7 +80,7 @@ jobs:
     needs: [boinc-macIntel64, gwnum]
     runs-on: macos-15-intel
     env:
-      SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+      SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
       LIBCXX_INCLUDE: /opt/libcxx-11/include/c++/v1
 
     steps:
@@ -107,12 +107,12 @@ jobs:
           key: gwmum-${{ runner.os }}-${{ env.gwnum_ver }}-macIntel64
           fail-on-cache-miss: true
 
-      - name: setup MacOSX10.14 SDK
+      - name: setup MacOSX10.15 SDK
         run: |
-          wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz
-          xz -c -d MacOSX10.14.sdk.tar.xz | tar -xf -
-          sudo mv MacOSX10.14.sdk "$SDKROOT"
-          sudo /usr/libexec/PlistBuddy -c "Set :MinimumSDKVersion 10.14" /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Info.plist
+          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.15.sdk.tar.xz
+          xz -c -d MacOSX10.15.sdk.tar.xz | tar -xf -
+          sudo mv MacOSX10.15.sdk "$SDKROOT"
+          sudo /usr/libexec/PlistBuddy -c "Set :MinimumSDKVersion 10.15" /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Info.plist
 
       - name: install deps (brew)
         run: brew install gmp

--- a/src/mac64/Makefile
+++ b/src/mac64/Makefile
@@ -9,7 +9,7 @@ COMPOBJS        = $(COMPOBJS_COMMON) prst.o
 
 # libc++ headers to use. Download and extract from https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/libcxx-11.0.1.src.tar.xz
 LIBCXX_INCLUDE ?= /opt/libcxx-11/include/c++/v1
-SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
 MINVER  = 10.14
 
 # some tools use this env var as well, so set it as well


### PR DESCRIPTION
As gwnum won't compile on MacOS ARM64, I have substituted in MacOS AMD64 and updated the MacOS SDK to work with v15.