### PR TITLE
Fix MorrisonGeneric/PocklingtonGeneric reporting time: 0.0 s.

### DIFF
--- a/src/morrison.cpp
+++ b/src/morrison.cpp
@@ -531,6 +531,7 @@ void MorrisonGeneric::run(arithmetic::GWState& gwstate, File& file_checkpoint, F
                     Product taskP(G.begin(), G.end());
                     taskP.init(&input, &gwstate, _logging.get());
                     taskP.run();
+                    logging.progress().add_time(taskP.timer());
                     tmp = std::move(taskP.result());
                     if (a)
                         Task::abort();
@@ -728,6 +729,7 @@ void MorrisonGeneric::run(arithmetic::GWState& gwstate, File& file_checkpoint, F
                 stack_value.emplace_back(0, task_num, std::move(*cur_task->result()), cur_task->negativeQ() && cur_task->result_parity());
                 last_progress += cur_task->timer();
                 last_write += cur_task->timer();
+                logging.progress().add_time(cur_task->timer());
                 _logging->progress().next_stage();
                 cur_task.reset();
                 if (checkpoint)

--- a/src/pocklington.cpp
+++ b/src/pocklington.cpp
@@ -377,6 +377,7 @@ void PocklingtonGeneric::run(arithmetic::GWState& gwstate, File& file_checkpoint
                 Product taskP(G.begin(), G.end());
                 taskP.init(&input, &gwstate, _logging.get());
                 taskP.run();
+                logging.progress().add_time(taskP.timer());
                 tmp = std::move(taskP.result());
             }
             else
@@ -499,6 +500,7 @@ void PocklingtonGeneric::run(arithmetic::GWState& gwstate, File& file_checkpoint
                 if (stack.size() == 1)
                     exp = std::move(cur_task->exp());
                 last_progress += cur_task->timer();
+                logging.progress().add_time(cur_task->timer());
                 _logging->progress().next_stage();
                 cur_task.reset();
 


### PR DESCRIPTION
## Summary

Fixes the `time: 0.0 s.` display in result lines for `prst <num> -d` (Morrison) and `-pocklington` paths that go through `MorrisonGeneric` / `PocklingtonGeneric`.

Reported on Mersenne Forum: https://www.mersenneforum.org/node/22212?p=1112407#post1112407

Example before/after (Windows):

```
$ prst 30006!4-1 -d
Morrison test of 30006!4-1, P = 135, Q = -1.
30006!4-1 Gerbicz-Li check enabled.
30006!4-1 is not a probable prime. Have you run Fermat test first? RES64: FC0CB65D048C281F, time: 0.0 s.   <-- BUG
```

After the fix the same invocation reports `time: 14.3 s.` (the actual elapsed wall-clock).

## Root cause

`MorrisonGeneric` (`src/morrison.cpp:455-456`) and `PocklingtonGeneric` (`src/pocklington.cpp:249-250`) drive their inner tasks through a `SubLogging` whose `progress().set_parent(nullptr)` is set deliberately — without that, per-task `update()` calls would clobber the outer logical progress fraction maintained by `progress_factors()`.

But `set_parent(nullptr)` also blocks time propagation. All elapsed time accumulates in `_logging->progress()._time_total`, and the result lines query the *outer* `logging.progress().time_total()` — which sees zero unless `progress_factors()` happened to be called recently.

This is more than a display bug: `progress_save()` persists `progress().time_total()`, so resumed `MorrisonGeneric` / `PocklingtonGeneric` runs were also losing all elapsed-time history.

## Fix

After each inner task completes, push its `timer()` into the outer progress via a new `Progress::add_time(double)` accessor. `add_time()` is intent-explicit and side-effect-free (it bumps `_time_total` only), avoiding the `_cur_progress` clobber that prevented us from just calling `update()`.

Touched call sites:
- `src/morrison.cpp` — after `cur_task->run()` and after `taskP.run()` inside `test_G()`.
- `src/pocklington.cpp` — analogous two sites.

The submodule pointer is bumped to pick up the new accessor.

## Dependency

This PR depends on the framework-side change adding `Progress::add_time()`:
**patnashev/arithmetic#5** — https://github.com/patnashev/arithmetic/pull/5

The two need to land together. Until that one merges, the gitlink in this PR points at a SHA that lives only on `PrestackI/arithmetic` (the fork), so a fresh clone of this branch can't resolve it without adding the fork as a remote in `framework/`.

## Test plan

- [x] Build Release|x64 with VS 2022 BuildTools (`v143` toolset, Windows SDK 10.0.26100.0). No new warnings or errors.
- [x] `prst 30006!4-1 -d` now reports a non-zero `time:` value (14.3 s on my box).
- [x] `prst 30006!4-1 -d -fermat` (the already-working path) still reports correctly — no regression.
- [ ] Resume scenario (interrupt + restart of a long Morrison test): expect `time_total` in the saved progress file to grow as the test runs.