### PR TITLE
Add NewPGen sieve-file support to -batch (and -stop on primek)

### DIFF
--- a/src/abc_parser.cpp
+++ b/src/abc_parser.cpp
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstring>
+#include <cstdio>
 #include <cmath>
 
 #include "gwnum.h"
@@ -60,6 +61,28 @@ static bool has_prefix_ci(const std::string& s, const char* prefix)
     return true;
 }
 
+static bool is_digit_string(const std::string& s)
+{
+    if (s.empty())
+        return false;
+    for (char ch : s)
+        if (!std::isdigit((unsigned char)ch))
+            return false;
+    return true;
+}
+
+// Parse a NewPGen header: <sievelimit>:<char>:<chainlen>:<base>:<mask>
+// Returns the number of fields scanned; >= 4 means a valid header.
+static int parse_newpgen_header(const std::string& line,
+                                unsigned long long& sievelimit, char& mode_char,
+                                unsigned long& chainlen, unsigned long long& base,
+                                unsigned long& mask)
+{
+    sievelimit = 0; mode_char = 0; chainlen = 0; base = 0; mask = 0;
+    return std::sscanf(line.c_str(), "%llu:%c:%lu:%llu:%lu",
+                       &sievelimit, &mode_char, &chainlen, &base, &mask);
+}
+
 FileFormat detect_format(const std::string& first_line)
 {
     if (has_prefix_ci(first_line, "ABCD "))
@@ -68,6 +91,17 @@ FileFormat detect_format(const std::string& first_line)
         return FORMAT_ABC2;
     if (has_prefix_ci(first_line, "ABC "))
         return FORMAT_ABC;
+
+    // NewPGen sieve header (e.g. "1000000000000:M:1:105:258"). Requires >= 4
+    // colon-separated fields so a stray "123:foo" line is not misdetected.
+    {
+        unsigned long long sievelimit, base;
+        char mode_char;
+        unsigned long chainlen, mask;
+        if (parse_newpgen_header(first_line, sievelimit, mode_char, chainlen, base, mask) >= 4)
+            return FORMAT_NEWPGEN;
+    }
+
     return FORMAT_UNKNOWN;
 }
 
@@ -699,12 +733,153 @@ static std::unique_ptr<CandidateSource> parse_abc2_source(
 }
 
 // ============================================================================
+// NewPGen format parser (materializes into vectors)
+//
+// Standard NewPGen sieve output, as read by LLR. Header:
+//   <sievelimit>:<char>:<chainlen>:<base>:<mask>
+// followed by "k n" data lines (k-first). Only the single-test forms
+// k*b^n+1 (MODE_PLUS / 'P') and k*b^n-1 (MODE_MINUS / 'M') are supported;
+// every other form (twin, SG, CC, chains, primorial, +5/+7, AP, dual) is
+// warned about and skipped. Column order can be reversed to "n k" via
+// col_order == NEWPGEN_NK for merge scripts that emit n first.
+// ============================================================================
+
+static bool parse_newpgen_file(
+    const std::vector<std::string>& raw_lines,
+    std::vector<std::string>& out_batch,
+    std::vector<std::string>& out_batch_k,
+    int col_order,
+    Logging& logging)
+{
+    // NewPGen mask bits (see Llr.c:222-237). Non-form flags are stripped before
+    // matching: 0x100 = "Mode 'k' sieve" (variable k), 0x400 = NOTGENERALISED.
+    const unsigned long MODE_PLUS  = 0x01;
+    const unsigned long MODE_MINUS = 0x02;
+    const unsigned long MODE_PRIMORIAL = 0x40;
+    const unsigned long NON_FORM_FLAGS = 0x100UL | 0x400UL;
+
+    bool any_header = false;
+    int header_count = 0;
+
+    // Current block state (reset on every header line).
+    bool block_valid = false;
+    int block_sign = 0;            // +1 for k*b^n+1, -1 for k*b^n-1
+    std::string block_base;        // base, as a string
+    size_t block_rows = 0;         // candidates emitted in the current block
+
+    for (size_t i = 0; i < raw_lines.size(); i++)
+    {
+        const std::string& raw_line = raw_lines[i];
+        if (is_skip_line(raw_line))
+            continue;
+
+        unsigned long long sievelimit = 0, base = 0;
+        char mode_char = 0;
+        unsigned long chainlen = 0, mask = 0;
+        int fields = parse_newpgen_header(raw_line, sievelimit, mode_char, chainlen, base, mask);
+        if (fields >= 4)
+        {
+            // Start a new block; reset all per-block state.
+            any_header = true;
+            header_count++;
+            block_valid = false;
+            block_sign = 0;
+            block_rows = 0;
+            block_base = std::to_string(base);
+
+            if (fields < 5)
+                mask = 0;   // LLR: a 4-field header falls back to the char code
+
+            int sign = 0;
+            if (mask & MODE_PRIMORIAL)
+            {
+                logging.warning("NewPGen: primorial form (mask 0x40) is not supported; skipping block at line %d.\n", (int)i + 1);
+            }
+            else if (mask != 0)
+            {
+                unsigned long form_bits = mask & ~NON_FORM_FLAGS;
+                if (form_bits == MODE_PLUS)
+                    sign = +1;
+                else if (form_bits == MODE_MINUS)
+                    sign = -1;
+                else
+                    logging.warning("NewPGen: unsupported form (mask %lu) at line %d; only k*b^n+1 and k*b^n-1 are handled, skipping block.\n", mask, (int)i + 1);
+            }
+            else
+            {
+                char c = (char)std::toupper((unsigned char)mode_char);
+                if (c == 'P')
+                    sign = +1;
+                else if (c == 'M')
+                    sign = -1;
+                else
+                    logging.warning("NewPGen: unsupported type '%c' at line %d; only P and M are handled, skipping block.\n", mode_char, (int)i + 1);
+            }
+
+            if (sign != 0)
+            {
+                block_valid = true;
+                block_sign = sign;
+                logging.info("NewPGen header: base %s, form k*%s^n%s, columns %s.\n",
+                    block_base.data(), block_base.data(), sign > 0 ? "+1" : "-1",
+                    col_order == NEWPGEN_NK ? "n k (reversed)" : "k n");
+            }
+            continue;
+        }
+
+        // Data line: flush until a valid header has been seen.
+        if (!block_valid)
+            continue;
+
+        std::istringstream iss(raw_line);
+        std::string t0, t1;
+        if (!(iss >> t0 >> t1))
+        {
+            logging.warning("NewPGen: skipping malformed data line %d: %s\n", (int)i + 1, raw_line.data());
+            continue;
+        }
+
+        std::string k_str, n_str;
+        if (col_order == NEWPGEN_NK)
+        {
+            n_str = t0;
+            k_str = t1;
+        }
+        else
+        {
+            k_str = t0;
+            n_str = t1;
+        }
+
+        if (!is_digit_string(k_str) || !is_digit_string(n_str))
+        {
+            logging.warning("NewPGen: skipping non-numeric data line %d: %s\n", (int)i + 1, raw_line.data());
+            continue;
+        }
+
+        std::string expression = k_str + "*" + block_base + "^" + n_str + (block_sign > 0 ? "+1" : "-1");
+
+        if (block_rows == 0)
+            logging.info("NewPGen: first candidate %s (k=%s).\n", expression.data(), k_str.data());
+
+        out_batch.push_back(std::move(expression));
+        out_batch_k.push_back(std::move(k_str));
+        block_rows++;
+    }
+
+    if (any_header)
+        logging.info("NewPGen: parsed %d header block(s), %d candidates.\n", header_count, (int)out_batch.size());
+    return any_header && !out_batch.empty();
+}
+
+// ============================================================================
 // Factory: parse_batch_file
 // ============================================================================
 
 std::unique_ptr<CandidateSource> parse_batch_file(
     const std::string& filename,
-    Logging& logging)
+    Logging& logging,
+    int newpgen_column_order)
 {
     File batch_file(filename, 0);
     batch_file.read_buffer();
@@ -773,6 +948,18 @@ std::unique_ptr<CandidateSource> parse_batch_file(
             return std::unique_ptr<CandidateSource>(
                 new VectorCandidateSource(std::move(batch), std::move(batch_k), true));
         }
+    }
+
+    if (format == FORMAT_NEWPGEN)
+    {
+        std::vector<std::string> batch, batch_k;
+        if (!parse_newpgen_file(raw_lines, batch, batch_k, newpgen_column_order, logging))
+        {
+            logging.warning("NewPGen batch %s has no supported candidates.\n", filename.data());
+            return nullptr;
+        }
+        return std::unique_ptr<CandidateSource>(
+            new VectorCandidateSource(std::move(batch), std::move(batch_k), true));
     }
 
     // Raw format: each line is an expression, no k-values

--- a/src/abc_parser.h
+++ b/src/abc_parser.h
@@ -36,9 +36,13 @@ static const size_t MAX_ABC2_IN_LIST_VALUES = 1000;
 // File format detection
 // ============================================================================
 
-enum FileFormat { FORMAT_UNKNOWN, FORMAT_ABC, FORMAT_ABCD, FORMAT_ABC2 };
+enum FileFormat { FORMAT_UNKNOWN, FORMAT_ABC, FORMAT_ABCD, FORMAT_ABC2, FORMAT_NEWPGEN };
 
 FileFormat detect_format(const std::string& first_line);
+
+// NewPGen data-line column order. Standard NewPGen (and LLR) is k-first ("k n");
+// NEWPGEN_NK is for files whose columns are reversed ("n k").
+enum NewPgenColumnOrder { NEWPGEN_KN = 0, NEWPGEN_NK = 1 };
 
 // ============================================================================
 // Candidate: a single number expression with optional k-value for tracking
@@ -85,4 +89,5 @@ public:
 
 std::unique_ptr<CandidateSource> parse_batch_file(
     const std::string& filename,
-    Logging& logging);
+    Logging& logging,
+    int newpgen_column_order = NEWPGEN_KN);

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -44,6 +44,7 @@ int batch_main(int argc, char *argv[])
     bool stop_prime = false;
     int stop_composites = 0;
     bool stop_k_prime = false;
+    int newpgen_col_order = NEWPGEN_KN;
 
     Config cnfg;
     cnfg.ignore("-batch")
@@ -101,9 +102,11 @@ int batch_main(int argc, char *argv[])
                 .check("error", stop_error, true)
                 .check("prime", stop_prime, true)
                 .value_number("composites", ' ', stop_composites, 1, INT_MAX)
+                .check("primek", stop_k_prime, true)
                 .check("kprime", stop_k_prime, true)
                 .end()
             .end()
+        .value_enum("-newpgen", ' ', newpgen_col_order, Enum<int>().add("kn", NEWPGEN_KN).add("nk", NEWPGEN_NK))
         .value_code("-ini", ' ', [&](const char* param) {
                 File ini_file(param, 0);
                 ini_file.read_buffer();
@@ -136,8 +139,11 @@ int batch_main(int argc, char *argv[])
         printf("\t-order {<a> | \"K*B^N+C\"}\n");
         printf("\t-factors all\n");
         printf("\t-check [{near | always| never}] [strong [disable] [count <count>]]\n");
-        printf("\t-stop [on error] [on prime] [on composites <count>] [on kprime]\n");
-        printf("Batch file formats: raw (one expression per line), ABC, ABCD, ABC2\n");
+        printf("\t-stop [on error] [on prime] [on primek] [on composites <count>]\n");
+        printf("\t\ton prime stops the whole batch; on primek stops only the current k.\n");
+        printf("\t-newpgen {kn | nk}\n");
+        printf("\t\tNewPGen data-line column order (k-first default, nk for reversed files).\n");
+        printf("Batch file formats: raw (one expression per line), ABC, ABCD, ABC2, NewPGen\n");
         return PRST_EXIT_NORMAL;
     }
 
@@ -151,7 +157,7 @@ int batch_main(int argc, char *argv[])
 
     if (batch_name != "stdin")
     {
-        source = parse_batch_file(batch_name, logging_batch);
+        source = parse_batch_file(batch_name, logging_batch, newpgen_col_order);
         if (!source || source->size() == 0)
         {
             logging_batch.warning("Batch %s is empty or could not be parsed.\n", batch_name.data());


### PR DESCRIPTION
## Summary

Adds **NewPGen** sieve-file reading to `-batch`, so PRST can consume the classic NewPGen sieve format directly (as LLR does), alongside the existing ABC / ABCD / ABC2 / raw formats.

## Format handling

- Header `<sievelimit>:<char>:<chainlen>:<base>:<mask>`, recognized by `detect_format` (requires ≥4 colon-separated fields, so a stray `123:foo` line is not misdetected).
- Data rows `k n` → `k*b^n±1` candidates.
- Only the single-test forms are supported: `MODE_PLUS`/`P` → `k*b^n+1`, `MODE_MINUS`/`M` → `k*b^n-1`. The form is matched **after stripping the non-form flags** `0x100` (variable-k) and `0x400` (NOTGENERALISED) — e.g. a real header mask `258 = 0x100|0x02` decodes as MINUS. Every other form (twin, SG, CC, BiTwin, chains, primorial, +5/+7, AP, dual) is warned about and skipped, never silently mis-tested.
- Multiple header blocks per file are supported (per-block state reset).
- `k` is kept as a string token (it may exceed 64 bits).

## Column order

Columns default to **k-first** (as LLR reads them, `sscanf(buf,"%s %lu",sgk,&n)`). A new `-newpgen nk` flag reads column-reversed (`n k`) files; only which token is treated as `k` changes — the produced candidates are identical.

## `-stop on primek`

Exposes the existing per-k stop under the name `primek` (with `kprime` kept as an alias): once a (probable) prime is found for a given `k`, that `k`'s remaining candidates are skipped while the batch continues for other `k` values. This is distinct from `-stop on prime`, which halts the whole batch.

## Testing

Verified against real Riesel base-105 NewPGen sieve output (header `…:M:1:105:258`):
- header + column decode via `-batch … -info` (each row → `k*105^n-1`),
- the per-k skip firing once a prime is found (using Mersenne primes above the small-number fast path),
- the `-newpgen nk` round-trip producing identical candidates,
- an unsupported-form (twin) header yielding a clean empty batch rather than parse errors.

## Notes

- The companion documentation lives in `docs/abc-batch.md`, which is not in `main` yet (it is part of a separate docs contribution); the NewPGen doc section will follow once that lands. The CLI usage text in `batch.cpp` covers discoverability in the meantime.

Files: `src/abc_parser.{h,cpp}`, `src/batch.cpp`.
