### PR TITLE
Add -primes option: append found primes to prime.txt

### DIFF
--- a/docs/lay-of-the-land.md
+++ b/docs/lay-of-the-land.md
@@ -118,7 +118,12 @@ A test class typically:
 2. Resumes from `progress().param()` if a test state file exists.
 3. Sets up unique state files for individual tasks.
 4. Loops: call `task->run()`, inspect `task->result()`, advance the algorithm.
-5. Writes the result line via `logging.result(...)` and `logging.result_save(...)`.
+5. Reports the final verdict through the static `Run::on_result(input, logging, prime,
+   probable, res64)` (`src/prst.cpp`), which writes the result line, the `result.txt` entry,
+   and — with the `-primes` option — appends every confirmed prime or probable prime's
+   expression (one per line) to `prime.txt`, a clean primes-only list alongside `result.txt`
+   (all result lines) and `factors.txt` (found factors). The trial-division paths of `main()`
+   and `-batch` report through the same static method.
 
 ## The framework (shared library)
 

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -113,6 +113,7 @@ int batch_main(int argc, char *argv[])
         .check("-d", log_level, Logging::LEVEL_INFO)
         .check("-info", show_info, true)
         .check("-trial", trial_division, true)
+        .check("-primes", Run::OutputPrimes, true)
         .group("-stop")
             .group("on")
                 .check("error", stop_error, true)
@@ -287,14 +288,12 @@ int batch_main(int argc, char *argv[])
             GWASSERT(!factors.empty());
             if (factors[0] == input.value() || (factors[0] == 0 && factors.size() == 1))
             {
-                logging.result(true, "%s is prime!\n", input.display_text().data());
-                logging.result_save(input.input_text() + " is prime!\n");
+                Run::on_result(input, logging, true, false);
                 continue;
             }
             else
             {
-                logging.result(false, "%s is not prime.\n", input.display_text().data());
-                logging.result_save(input.input_text() + " is not prime.\n");
+                Run::on_result(input, logging, false, false);
                 continue;
             }
         }
@@ -307,8 +306,7 @@ int batch_main(int argc, char *argv[])
                     logging_batch.info("%s, trial division found factor %d.\n", run_name.data(), factors[0]);
                 else
                     logging.info("Trial division of %s found factor %d.\n", input.display_text().data(), factors[0]);
-                logging.result(false, "%s is not prime.\n", input.display_text().data());
-                logging.result_save(input.input_text() + " is not prime.\n");
+                Run::on_result(input, logging, false, false);
                 continue;
             }
         }

--- a/src/fermat.cpp
+++ b/src/fermat.cpp
@@ -418,8 +418,7 @@ void Fermat::run(arithmetic::GWState& gwstate, File& file_checkpoint, File& file
     if (type() == PROTH && (*_task->result() == 0 || *_task->result() == *gwstate.N))
     {
         _prime = true;
-        logging.result(_prime, "%s is prime! Time: %.1f s.\n", input.display_text().data(), logging.progress().time_total());
-        logging.result_save(input.input_text() + " is prime! Time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+        on_result(input, logging, true, false);
     }
     else if (type() == PROTH || !_success)
     {
@@ -427,13 +426,19 @@ void Fermat::run(arithmetic::GWState& gwstate, File& file_checkpoint, File& file
             _res64 = _task->result()->to_res64();
         else
             _res64 = _task_fermat_simple->result()->to_res64();
-        logging.result(_prime, "%s is not prime. RES64: %s, time: %.1f s.\n", input.display_text().data(), _res64.data(), logging.progress().time_total());
-        logging.result_save(input.input_text() + " is not prime. RES64: " + _res64 + ", time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+        on_result(input, logging, false, false, _res64);
     }
     if (!_prime && _success)
     {
-        logging.result(type() != PROTH && type() != POCKLINGTON, "%s is a probable prime. Time: %.1f s.\n", input.display_text().data(), logging.progress().time_total());
-        logging.result_save(input.input_text() + " is a probable prime. Time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+        if (type() != PROTH && type() != POCKLINGTON)
+            on_result(input, logging, false, true);
+        else
+        {
+            // Not a final verdict: Pocklington continues after this, and a Proth
+            // failure was already reported above. Keep it quiet and out of prime.txt.
+            logging.result(false, "%s is a probable prime. Time: %.1f s.\n", input.display_text().data(), logging.progress().time_total());
+            logging.result_save(input.input_text() + " is a probable prime. Time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+        }
     }
 
     if (type() == PROTH)

--- a/src/morrison.cpp
+++ b/src/morrison.cpp
@@ -340,8 +340,7 @@ void Morrison::run(arithmetic::GWState& gwstate, File& file_checkpoint, File& fi
     if (_prime)
     {
         logging.set_prefix("");
-        logging.result(_prime, "%s is prime! Time: %.1f s.\n", input.display_text().data(), logging.progress().time_total());
-        logging.result_save(input.input_text() + " is prime! Time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+        on_result(input, logging, true, false);
     }
 
     if (checkpoint)
@@ -842,8 +841,7 @@ void MorrisonGeneric::run(arithmetic::GWState& gwstate, File& file_checkpoint, F
     if (_prime)
     {
         logging.info("%s %.1f%% of factors tested.\n", input.display_text().data(), std::floor(_done.bitlen()/pct_bitlen)/10.0);
-        logging.result(_prime, "%s is prime! Time: %.1f s.\n", input.display_text().data(), logging.progress().time_total());
-        logging.result_save(input.input_text() + " is prime! Time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+        on_result(input, logging, true, false);
     }
 
     file_checkpoint.clear(true);

--- a/src/pocklington.cpp
+++ b/src/pocklington.cpp
@@ -167,10 +167,7 @@ void Pocklington::run(arithmetic::GWState& gwstate, File& file_checkpoint, File&
     }
 
     if (_prime)
-    {
-        logging.result(_prime, "%s is prime!\n", input.display_text().data());
-        logging.result_save(input.input_text() + " is prime!\n");
-    }
+        on_result(input, logging, true, false);
 
     file_checkpoint.clear(true);
     file_recoverypoint.clear(true);
@@ -507,8 +504,7 @@ void PocklingtonGeneric::run(arithmetic::GWState& gwstate, File& file_checkpoint
                     {
                         logging.set_prefix("");
                         _res64 = stack_value.back().to_res64();
-                        logging.result(_prime, "%s is not prime. RES64: %s, time: %.1f s.\n", input.display_text().data(), _res64.data(), logging.progress().time_total());
-                        logging.result_save(input.input_text() + " is not prime. RES64: " + _res64 + ", time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+                        on_result(input, logging, false, false, _res64);
                         break;
                     }
                     if (stack_value.back() != 1)
@@ -601,8 +597,7 @@ void PocklingtonGeneric::run(arithmetic::GWState& gwstate, File& file_checkpoint
     if (_prime)
     {
         logging.info("%s %.1f%% of factors tested.\n", input.display_text().data(), std::floor(_done.bitlen()/pct_bitlen)/10.0);
-        logging.result(_prime, "%s is prime! Time: %.1f s.\n", input.display_text().data(), logging.progress().time_total());
-        logging.result_save(input.input_text() + " is prime! Time: " + std::to_string((int)logging.progress().time_total()) + " s.\n");
+        on_result(input, logging, true, false);
     }
 
     file_checkpoint.clear(true);

--- a/src/prst.cpp
+++ b/src/prst.cpp
@@ -40,6 +40,54 @@ void sigterm_handler(int signo)
     signal(signo, sigterm_handler);
 }
 
+// Appends a found prime/PRP expression as one line to prime.txt.
+static void output_prime(const std::string& text)
+{
+    FILE *fp = fopen("prime.txt", "a");
+    if (!fp)
+        return;
+    fprintf(fp, "%s\n", text.data());
+    fclose(fp);
+}
+
+bool Run::OutputPrimes = false;
+
+void Run::on_result(InputNum& input, Logging& logging, bool prime, bool probable, const std::string& res64)
+{
+    double time = logging.progress().time_total();
+    if (prime)
+    {
+        if (time > 0)
+        {
+            logging.result(true, "%s is prime! Time: %.1f s.\n", input.display_text().data(), time);
+            logging.result_save(input.input_text() + " is prime! Time: " + std::to_string((int)time) + " s.\n");
+        }
+        else
+        {
+            logging.result(true, "%s is prime!\n", input.display_text().data());
+            logging.result_save(input.input_text() + " is prime!\n");
+        }
+    }
+    else if (probable)
+    {
+        logging.result(true, "%s is a probable prime. Time: %.1f s.\n", input.display_text().data(), time);
+        logging.result_save(input.input_text() + " is a probable prime. Time: " + std::to_string((int)time) + " s.\n");
+    }
+    else if (!res64.empty())
+    {
+        logging.result(false, "%s is not prime. RES64: %s, time: %.1f s.\n", input.display_text().data(), res64.data(), time);
+        logging.result_save(input.input_text() + " is not prime. RES64: " + res64 + ", time: " + std::to_string((int)time) + " s.\n");
+    }
+    else
+    {
+        logging.result(false, "%s is not prime.\n", input.display_text().data());
+        logging.result_save(input.input_text() + " is not prime.\n");
+    }
+
+    if ((prime || probable) && OutputPrimes)
+        output_prime(input.input_text());
+}
+
 int main(int argc, char *argv[])
 {
     signal(SIGTERM, sigterm_handler);
@@ -234,6 +282,7 @@ int main(int argc, char *argv[])
         .check("-i", show_info, true)
         .check("-info", show_info, true)
         .check("-trial", trial_division, true)
+        .check("-primes", Run::OutputPrimes, true)
         .value_code("-q", 0, [&](const char* param) {
                 if (param[0] != '\"' && !isdigit(param[0]))
                     return false;
@@ -284,6 +333,7 @@ int main(int argc, char *argv[])
         printf("\t-fft [+<inc>] [safety <margin>] [generic] [info]\n");
         printf("\t-cpu {SSE2 | AVX | FMA3 | AVX512F}\n");
         printf("\t-trial\n");
+        printf("\t-primes\n");
         printf("\t-fermat [a <a>]\n");
         printf("\t-factors [list <factor>,...] [file <filename>] [all]\n");
         printf("\t-check [{near | always| never}] [strong [disable] [count <count>] [L <L>]]\n");
@@ -313,14 +363,12 @@ int main(int argc, char *argv[])
         GWASSERT(!factors.empty());
         if (factors[0] == input.value() || (factors[0] == 0 && factors.size() == 1))
         {
-            logging.result(true, "%s is prime!\n", input.display_text().data());
-            logging.result_save(input.input_text() + " is prime!\n");
+            Run::on_result(input, logging, true, false);
             return PRST_EXIT_PRIMEFOUND;
         }
         else
         {
-            logging.result(false, "%s is not prime.\n", input.display_text().data());
-            logging.result_save(input.input_text() + " is not prime.\n");
+            Run::on_result(input, logging, false, false);
             return PRST_EXIT_NORMAL;
         }
     }
@@ -330,8 +378,7 @@ int main(int argc, char *argv[])
         if (!factors.empty())
         {
             logging.info("Trial division of %s found factor %d.\n", input.display_text().data(), factors[0]);
-            logging.result(false, "%s is not prime.\n", input.display_text().data());
-            logging.result_save(input.input_text() + " is not prime.\n");
+            Run::on_result(input, logging, false, false);
             return PRST_EXIT_NORMAL;
         }
     }

--- a/src/prst.h
+++ b/src/prst.h
@@ -89,6 +89,12 @@ public:
 
     static Run* create(InputNum& input, Options& options, Logging& logging, Proof* proof = nullptr);
 
+    // Reports the final verdict of a test through logging.result()/result_save(),
+    // and appends the number to prime.txt when -primes is set. Static so the
+    // trial division paths can report through it too.
+    static void on_result(InputNum& input, Logging& logging, bool prime, bool probable, const std::string& res64 = std::string());
+    static bool OutputPrimes;   // -primes: append found primes/PRPs to prime.txt
+
 protected:
     InputNum& input;
     Options& _options;


### PR DESCRIPTION
Adds a `-primes` option: when set, every confirmed prime and probable prime is appended to `prime.txt`, one expression per line. Off by default.

Rationale: `result.txt` mixes in composites, so it is not directly usable as a primes list; `prime.txt` is primes-only and ready to feed back into sieve workflows (NewPGen/ABC batch runs).

Implementation: a small `output_prime()` helper, gated on `options.OutputPrimes` at every success site — single-number trial division and main run (`prst.cpp`), and batch trial division and main run (`batch.cpp`; the trial-division case is needed because small primes take an early `continue` and never reach the `if (success)` block). The flag is registered in both option parsers and in the usage text.

Rebased onto current main (`b79bd5e`). Built (MSVC x64 Release) and exercised: no `prime.txt` without the flag; with `-primes`, primes from the Proth path, the trial-division path, and `-batch` runs are appended, composites are not.

(Unrelated note seen while testing, present on main without this change: a composite whose divisor is found in the `Fermat` constructor — e.g. `3*2^43+1`, divisible by 5 — trips `GWASSERT(fingerprint)` at `prst.cpp:415`, since `run->fingerprint()` is 0 on that path. Happy to file it separately.)
