### PR TITLE
Linux build action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,108 @@
+name: Linux build
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  boinc_ref: 82d0a3731c743884b6e7a25d68c6558eca691635  # client release 7.20.2
+
+jobs:
+  boinc-linux64:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Cache BOINC libs
+        id: cache-boinc-linux64
+        uses: actions/cache@v5
+        with:
+          path: |
+            boinc/*.*
+            boinc/api
+            boinc/lib
+          key: boinc-${{ runner.os }}-${{ env.boinc_ref }}-linux64
+
+      - name: Checkout boinc
+        if: steps.cache-boinc-linux64.outputs.cache-hit != 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: 'BOINC/boinc'
+          ref: ${{ env.boinc_ref }}
+          path: 'boinc'
+
+      - name: install deps
+        if: steps.cache-boinc-linux64.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake libtool pkg-config m4
+
+      - name: build boinc
+        if: steps.cache-boinc-linux64.outputs.cache-hit != 'true'
+        run: |
+          cd ./boinc/
+          ./_autosetup
+          ./configure --disable-server --disable-client --disable-manager --enable-libraries --enable-static --disable-shared
+          make -j$(nproc)
+
+  linux64:
+    needs: [boinc-linux64]
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Use cached BOINC libs
+        id: cache-boinc
+        uses: actions/cache@v5
+        with:
+          path: |
+            boinc/*.*
+            boinc/api
+            boinc/lib
+          key: boinc-${{ runner.os }}-${{ env.boinc_ref }}-linux64
+          fail-on-cache-miss: true
+
+      - name: install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgmp-dev
+
+      - name: Checkout prst
+        uses: actions/checkout@v5
+        with:
+          submodules: 'true'
+          path: 'prst'
+
+      - name: make
+        run: cd prst/src/linux64 && make -j$(nproc)
+
+      - name: make (boinc)
+        run: cd prst/src/linux64 && make -f Makefile.boinc BOINC_DIR=$GITHUB_WORKSPACE/boinc -j$(nproc)
+
+      - name: smoke test
+        run: |
+          cd prst/src/linux64
+          file prst       | grep -q 'statically linked'
+          file prst_boinc | grep -q 'statically linked'
+          ./prst -v
+          ./prst_boinc -v
+          ./prst -log info "3*2^534+1" | tee proth.log
+          grep -q 'is prime!' proth.log
+
+      - name: check binaries run on other distros
+        run: |
+          for image in debian:11 alpine:3.19; do
+            echo "--- $image ---"
+            docker run --rm -v "$PWD/prst/src/linux64:/b:ro" "$image" /b/prst -v
+          done
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: linux64_bins
+          path: |
+            prst/src/linux64/prst
+            prst/src/linux64/prst_boinc


### PR DESCRIPTION
Adds `.github/workflows/linux.yml`, a Linux counterpart to the macOS action. Same triggers
(`release: created` + `workflow_dispatch`), same pinned BOINC ref, builds both `prst` and
`prst_boinc` and uploads them as `linux64_bins`.

Verified green on my fork:
https://github.com/PrestackI/prst/actions/runs/30678174110
(`boinc-linux64` 54s, `linux64` 1m0s, cold cache). The workflow itself only triggers on
release/manual, so it will not run on this PR.

### Two places it deliberately differs from macOS.yml

**No gwnum job.** The framework submodule already ships a matching GWnum 31.06 `linux64/gwnum.a`
(arithmetic `c266e57`, headers report `GWNUM_VERSION "31.6"`) plus `gwnum.ld`, so
`checkout` with `submodules: true` is enough and the p95 download/build is unnecessary.
The tradeoff: a future GWnum bump means committing a new lib rather than editing an env var.
I did verify the from-source path works on Ubuntu 24.04 if you would rather have parity —
p95's Linux 64-bit makefile is `gwnum/make64` (`makefile` is the 32-bit one), and
`make -f make64 -j gwnum.a polymult.a` builds clean. Happy to add the job if you prefer it.
Note `gwnum.ld` is not in the p95 zip, so it must keep coming from the submodule either way.

**`BOINC_DIR` is overridden on the make command line.** The checked-in
`src/linux64/Makefile.boinc` has `BOINC_DIR = ../../../../boinc/src`, which resolves outside
the CI workspace, and a `BOINC/boinc` checkout has `api/`, `lib/` and `_autosetup` at its
root with no `src/`. Rather than change your Makefile, the workflow passes
`BOINC_DIR=$GITHUB_WORKSPACE/boinc`. `BOINC_LIB`'s existing `-L$(BOINC_DIR)/api -L$(BOINC_DIR)/lib`
paths are then correct as written, because BOINC's `all-local` rule links `.libs/libboinc_api.a`
into `api/` and `.libs/libboinc.a` into `lib/` when configured with `--enable-static`.
Let me know if you would rather fix the Makefile instead and drop the override.

### Extra steps, easy to drop

Beyond a literal port I added a smoke test (asserts static linkage, runs `-v`, and requires a
real Proth test to print `is prime!` — it reported `3*2^534+1 is prime!` using an FMA3 FFT) and
a cross-distro check that runs the binary under `debian:11` and `alpine:3.19`. Alpine has no
glibc at all and the static binary still runs, which is the property that matters for handing
out artifacts. Say the word and I will remove either.

Actions are pinned at `checkout@v5` / `cache@v5` / `upload-artifact@v5` and the runner at
`ubuntu-24.04`. If you would prefer this to match macOS.yml's `@v3`/`@v4` exactly, I can
change it — I went newer because `cache@v3` is on GitHub's retirement path.
