### PR TITLE
Fixed -Wreorder warning in Run; helper factors in batch mode

### DIFF
--- a/docs/abc-batch.md
+++ b/docs/abc-batch.md
@@ -140,7 +140,8 @@ The parser surface (`abc_parser.h`) is tiny; the driver's option set is the larg
 | `-info` | `print_info` each candidate instead of testing (continues unless `-fft info`). |
 | `-trial` | trial-divide every candidate first; a found factor ⇒ "not prime", skip the full test. |
 | `-ini <file>` | read more options from an ini file (`Config::parse_ini`). |
-| `-t`, `-spin`, `-cpu`, `-fft`, `-check`, `-fermat`, `-order`, `-divides`, `-factors`, `-time`, `-d` | same meanings as in `main()`; parsed once into the shared `Options`, applied to each candidate's `GWState` via `options.configure` (`:333`). |
+| `-factors [list <f>,...] [file <fn>] [all]` | same meanings as in `main()`, but the parsed factors go into one pool shared by the whole batch rather than into a single `InputNum`. Each candidate absorbs them via `add_factor` after its own `parse` — a factor that divides no cofactor of that candidate is ignored, so one helper file may carry the factors of every k in the sieve. As in `main()`, entries are **trusted to be prime and are not verified**. |
+| `-t`, `-spin`, `-cpu`, `-fft`, `-check`, `-fermat`, `-order`, `-divides`, `-time`, `-d` | same meanings as in `main()`; parsed once into the shared `Options`, applied to each candidate's `GWState` via `options.configure` (`:333`). |
 
 Note `Task::PROGRESS_TIME = 60` is set at entry (`:39`) — batch runs report progress less chattily than the 1-candidate default.
 

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -39,6 +39,7 @@ int batch_main(int argc, char *argv[])
     Task::PROGRESS_TIME = 60;
 
     std::string batch_name;
+    std::vector<Giant> factors;
     bool stop_error = false;
     bool stop_prime = false;
     int stop_composites = 0;
@@ -93,6 +94,34 @@ int batch_main(int argc, char *argv[])
                 .end()
             .end()
         .group("-factors")
+            .list("list", ' ', ',', false)
+                .value_code([&](const char* param) {
+                        Giant tmp;
+                        InputNum input_factor;
+                        if (!input_factor.parse(param) || (tmp = input_factor.value()) == 0)
+                            return false;
+                        if (tmp != 1)
+                            factors.emplace_back(std::move(tmp));
+                        return true;
+                    })
+                .end()
+            .value_code("file", ' ', [&](const char* param) {
+                    File factor_file(param, 0);
+                    factor_file.read_buffer();
+                    if (factor_file.buffer().empty())
+                        printf("factor file not found: %s.\n", param);
+                    else
+                    {
+                        std::unique_ptr<TextReader> reader(factor_file.get_textreader());
+                        Giant tmp;
+                        std::string factor;
+                        InputNum input_factor;
+                        while (reader->read_textline(factor))
+                            if (input_factor.parse(factor) && (tmp = input_factor.value()) != 0 && tmp != 1)
+                                factors.emplace_back(std::move(tmp));
+                    }
+                    return true;
+                })
             .check("all", options.AllFactors, true)
             .end()
         .group("-time")
@@ -154,7 +183,8 @@ int batch_main(int argc, char *argv[])
         printf("\t-fermat [a <a>]\n");
         printf("\t-order {<a> | \"K*B^N+C\"}\n");
         printf("\t-divides {f | gf | xgf} [limit 12]\n");
-        printf("\t-factors all\n");
+        printf("\t-factors [list <factor>,...] [file <filename>] [all]\n");
+        printf("\t\tprime factors of k, applied to every candidate they divide.\n");
         printf("\t-check [{near | always| never}] [strong [disable] [count <count>]]\n");
         printf("\t-stop [on error] [on prime] [on primek] [on composites <count>]\n");
         printf("\t\ton prime stops the whole batch; on primek stops only the current k.\n");
@@ -263,6 +293,11 @@ int batch_main(int argc, char *argv[])
             }
             continue;
         }
+        // Helper factors are a single pool shared by the whole batch. add_factor()
+        // ignores a factor that does not divide this candidate's cofactor, so one
+        // file may carry the factors of every k in the sieve.
+        for (auto& factor : factors)
+            input.add_factor(factor);
         if (show_info)
         {
             input.print_info();

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -184,7 +184,6 @@ int batch_main(int argc, char *argv[])
         printf("\t-order {<a> | \"K*B^N+C\"}\n");
         printf("\t-divides {f | gf | xgf} [limit 12]\n");
         printf("\t-factors [list <factor>,...] [file <filename>] [all]\n");
-        printf("\t\tprime factors of k, applied to every candidate they divide.\n");
         printf("\t-check [{near | always| never}] [strong [disable] [count <count>]]\n");
         printf("\t-stop [on error] [on prime] [on primek] [on composites <count>]\n");
         printf("\t\ton prime stops the whole batch; on primek stops only the current k.\n");
@@ -294,8 +293,7 @@ int batch_main(int argc, char *argv[])
             continue;
         }
         // Helper factors are a single pool shared by the whole batch. add_factor()
-        // ignores a factor that does not divide this candidate's cofactor, so one
-        // file may carry the factors of every k in the sieve.
+        // ignores a factor that does not divide this candidate's cofactor.
         for (auto& factor : factors)
             input.add_factor(factor);
         if (show_info)

--- a/src/prst.h
+++ b/src/prst.h
@@ -74,7 +74,7 @@ class Run
 {
 public:
     Run(InputNum& input_, Options& options) : input(input_), _options(options) { }
-    Run(const char* name, InputNum& input_, Options& options) : _name(name), input(input_), _options(options) { }
+    Run(const char* name, InputNum& input_, Options& options) : input(input_), _options(options), _name(name) { }
     virtual ~Run() { }
 
     const std::string& name() { return _name; }


### PR DESCRIPTION
Both of these come from questions Happy5214 raised on mersenneforum.

### 1. `-Wreorder` in the `Run` constructor

`Run(const char*, InputNum&, Options&)` initialized `_name` before `input` and `_options`, while the members are declared `input, _options, _name`. Because the constructor is defined inline in `prst.h`, GCC and Clang re-diagnose it in every translation unit that includes the header — 9 from `make`, plus 2 more from `make -f Makefile.boinc` recompiling `prst.cpp` as `prst_boinc.o`. 11 occurrences, 33 lines, all pointing at the same line.

Reordering the initializer list to match the declaration order silences all of them. Nothing changes at runtime: members are initialized in declaration order regardless, and the three initializers have no side effects. It also makes the 3-argument constructor consistent with the 2-argument one above it.

I checked the rest of the codebase with a `-Wall -Wextra` sweep over every TU in `COMPOBJS`; this is the only `-Wreorder` site in `src/` or `framework/`.

Before / after on the Linux build action:

| | `-Wreorder` | `-Woverloaded-virtual` | `-Wformat-overflow` |
|---|---|---|---|
| before | 33 | 78 | 3 |
| after | **0** | 78 | 3 |

The remaining 78 are the `init(InputNum*, ...)` overloads in `exp.h`/`lucasmul.h`/`proof.h` hiding `Task::init` (`framework/task.h:88`); the 3 are in BOINC's own `gui_rpc_client.cpp`. Happy to do the `overloaded-virtual` cleanup as a separate PR if you want it — it needs `using` declarations in ~20 classes, so it seemed worth asking first rather than bundling.

### 2. Helper factors in batch mode

`-factors list` and `-factors file` were accepted only by `main()`; `batch_main` registered just `-factors all`. The remaining tokens fell through to `default_code` and overwrote `batch_name`, so

```
PRST -batch sieve.txt -factors file helper.txt
```

silently ran `helper.txt` as the batch and exited 0, while putting the options before the filename ran the right batch but dropped the factors without a message.

The parsed factors now go into one pool shared by the whole batch, applied to each candidate with `add_factor()` after its own `parse()`. Since `add_factor()` ignores a factor that divides neither cofactor, a single helper file can carry the factors of every k in a sieve and each candidate picks up only its own — which is what makes this usable for the multiple-k case Happy5214 asked about:

```
$ PRST -batch sieve.txt -factors file helper.txt -d
1 of 2: 1152921504606849973*2^40+1, Pocklington test.
1152921504606849973*2^40+1 Checking gcd with factors {2, 1152921504606849973}.
1152921504606849973*2^40+1 is prime! Time: 0.1 s.
2 of 2: 1152921504606847067*2^40-1, Morrison test.
1152921504606847067*2^40-1 Checking gcd with factors {2, 1152921504606847067}.
1152921504606847067*2^40-1 is prime! Time: 0.0 s.
Batch of 2, primes: 2, time: 0.1 s.
```

`helper.txt` there has four entries; the two belonging to other numbers are skipped. Same trust model as `main()` — entries are assumed prime and not verified.

The option block is copied from `prst.cpp` rather than rewritten; the only deliberate difference is that factors accumulate into a `vector` instead of going straight into a single `InputNum`, since batch has no single input at option-parse time.

**One design question.** This is a global pool, matching how PFGW's `-h` works. The batch sources already extract a per-candidate `k_value` (used by `-stop on primek`), so a `k -> factors` map keyed on that string is also available and would be closer to true per-number factors. I went with the pool because it is the smaller change and handles the mixed-k sieve directly, but say the word if you'd prefer the map.

Also corrects the `-factors` row in `docs/abc-batch.md`, which claimed the whole group already worked in batch mode.

### Testing

- Linux build action: green, warning counts above.
- MSVC x64 Release: builds clean.
- `-test abc_parser`: pass. `-test all`: still running as I open this — no failures so far; I'll follow up with the result rather than leave it implied.
- Batch behaviour, verified on both the MSVC build and the Linux binary from the build action: `-factors list` and `-factors file`, options before and after the filename, ABC-format input, `-factors all` unchanged, and the no-`-factors` path still falling back to Fermat exactly as before.
